### PR TITLE
Fix typo in subiquity example

### DIFF
--- a/templates/design.html
+++ b/templates/design.html
@@ -190,7 +190,7 @@ network:
   ethernets:
     # configured by subiquity
     eno1:
-      dhcp4: true`
+      dhcp4: true
       </pre>
 
       <p>The installer wrote out a config which included elements for the explicitly chosen/configured wired device. The other NICs are unconfigured, as the installer should not make any assumptions about their future usage or configuration.</p>


### PR DESCRIPTION
## Done

Fixed typo

## QA

Verify no stray \` in the netplan.yaml example for Subiquity

## Issue / Card


## Screenshots

