### PR TITLE
Fix reference/examples redirect, after dirhtml docs configuration

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -36,7 +36,7 @@ def sitemap_links():
 @app.route("/reference")
 def reference():
     return redirect(
-        "https://netplan.readthedocs.io" "/en/latest/netplan-yaml.html",
+        "https://netplan.readthedocs.io" "/en/latest/netplan-yaml",
         code=302,
     )
 
@@ -44,7 +44,7 @@ def reference():
 @app.route("/examples")
 def examples():
     return redirect(
-        "https://netplan.readthedocs.io" "/en/latest/examples.html", code=302
+        "https://netplan.readthedocs.io" "/en/latest/examples", code=302
     )
 
 


### PR DESCRIPTION
webapp: Fix reference/examples redirect, after dirhtml RTD configuration

The upstream documentation on ReadTheDocs (RTD), changed to use the dirhtml renderer: https://github.com/canonical/netplan/commit/2dad7d1

## Done

Checked redirect of https://netplan-io-269.demos.haus/reference#properties-for-device-type-ethernets

## QA

[List of steps to QA the new features or prove the bug has been resolved]

## Issue / Card

https://bugs.launchpad.net/netplan/+bug/2020228

## Screenshots

[if relevant, include a screenshot]
