### PR TITLE
Invoke cookie policy before gtm

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -42,7 +42,11 @@
   {% block head_extra %}{% endblock %}
   <script src="{{ versioned_static('js/build/global-nav.js') }}"></script>
   <script src="{{ versioned_static('js/build/cookie-policy.js') }}"></script>
-
+  <script>
+    if (typeof cpNs !== "undefined") {
+      cpNs.cookiePolicy();
+    }
+  </script>
   <body>
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M95NRRR"
@@ -54,9 +58,6 @@
     {% endblock content %}
     {% include "footer.html" %}
     <script>
-      if (typeof cpNs !== "undefined") {
-        cpNs.cookiePolicy();
-      }
       if (typeof canonicalGlobalNav !== "undefined") {
         canonicalGlobalNav.createNav({breakpoint: 940});
       }


### PR DESCRIPTION
## Done

- Invoke cookie policy before google tag manager is called

## QA

[List of steps to QA the new features or prove the bug has been resolved]

## Issue / Card

[List of links to GitHub issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
